### PR TITLE
Publish pure AI prompt at standalone .md URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ docs/.obsidian/
 /static/*.md
 /static/llms.txt
 /static/llms-full.txt
+/static/Client/ai-integration-prompt.md

--- a/docs/Client/integration-prompt.md
+++ b/docs/Client/integration-prompt.md
@@ -12,6 +12,8 @@ A self-contained, end-to-end walkthrough for integrating the TrustedLogin Client
 
 **Or fetch this page as raw Markdown.** This page is also served at [`/Client/integration-prompt.md`](pathname:///Client/integration-prompt.md) — your AI assistant can fetch it directly. See [For AI assistants & tools](/for-ai-tools) for the full set of conventions (per-page Markdown, `<link rel="alternate">` discovery, `/llms.txt`, `/llms-full.txt`).
 
+**Or fetch only the prompt itself**, with no preamble or meta sections, at [`/Client/ai-integration-prompt.md`](pathname:///Client/ai-integration-prompt.md) — that's the pure body starting with "You are a senior WordPress plugin engineer". Useful for tools that take a prompt URL as input and don't need the human-facing wrapper.
+
 **Without an AI assistant:** Read it top-to-bottom as a more thorough version of [Installation](./02-installation) + [Namespacing with Strauss](./namespacing/strauss) + [Configuration](./configuration) + [Merging into an existing composer.json](./namespacing/merging-into-existing-composer). The prompt was distilled from end-to-end testing across real plugins and captures gotchas the per-step docs don't dwell on.
 
 The recipe is verified end-to-end by the [integration tests](https://github.com/trustedlogin/docs/tree/main/tests) in this docs repo — if you follow this prompt and the result differs from what the tests assert, the tests are ground truth.

--- a/docs/for-ai-tools.md
+++ b/docs/for-ai-tools.md
@@ -42,7 +42,7 @@ Both files are regenerated on every site build, so they're always in sync with t
 
 If you're an AI assistant integrating TrustedLogin into a customer's plugin:
 
-1. **For a focused integration task:** fetch [`/Client/integration-prompt.md`](pathname:///Client/integration-prompt.md) — it's a self-contained walkthrough including input collection, host-side conflict detection, the bootstrap, and a verification checklist.
+1. **For a focused integration task:** fetch [`/Client/ai-integration-prompt.md`](pathname:///Client/ai-integration-prompt.md) — pure prompt body, no preamble. Self-contained walkthrough including input collection, host-side conflict detection, the bootstrap, and a verification checklist. (The same page wrapped with human-friendly intro is at [`/Client/integration-prompt.md`](pathname:///Client/integration-prompt.md).)
 2. **For broader context (multiple docs):** fetch [`/llms-full.txt`](/llms-full.txt) — single fetch, full corpus.
 3. **For navigation and discovery:** fetch [`/llms.txt`](/llms.txt) and follow the per-section links.
 

--- a/scripts/mirror-md.js
+++ b/scripts/mirror-md.js
@@ -144,6 +144,28 @@ if ( ! fs.existsSync( SRC ) ) {
 
 walk( SRC );
 
+// /Client/ai-integration-prompt.md — pure prompt body, no frontmatter or
+// preamble. The /Client/integration-prompt page wraps the prompt with a
+// human-friendly "How to use it" intro; AI assistants want just the prompt
+// itself. Extract the body that follows the "## The prompt\n\n---\n" marker.
+{
+	const src = path.join( SRC, 'Client', 'integration-prompt.md' );
+	if ( fs.existsSync( src ) ) {
+		const raw = fs.readFileSync( src, 'utf-8' );
+		const noFrontmatter = raw.replace( /^---\n[\s\S]*?\n---\n?/, '' );
+		const m = noFrontmatter.match( /^## The prompt[\s\S]*?\n---\n+([\s\S]*)$/m );
+		if ( m ) {
+			const body = m[ 1 ].trim() + '\n';
+			const out = path.join( DEST, 'Client', 'ai-integration-prompt.md' );
+			fs.mkdirSync( path.dirname( out ), { recursive: true } );
+			fs.writeFileSync( out, body );
+			console.log( `mirror-md: extracted pure prompt → ${ path.relative( ROOT, out ) }` );
+		} else {
+			console.warn( 'mirror-md: could not locate prompt body in integration-prompt.md (looked for "## The prompt" + separator)' );
+		}
+	}
+}
+
 // /llms.txt — site index for AI crawlers, llmstxt.org format.
 {
 	const lines = [];

--- a/scripts/mirror-md.js
+++ b/scripts/mirror-md.js
@@ -57,18 +57,36 @@ const DOCUSAURUS_KEYS = new Set( [
 	'parse_number_prefixes',
 ] );
 
+// Strip Docusaurus-only link protocols that don't make sense in raw Markdown.
+// `pathname://` is a Docusaurus marker telling its MDX link resolver "this is
+// a literal URL, don't try to match it against doc IDs". The MDX renderer
+// strips it from rendered HTML, but if we copy the source verbatim into the
+// static mirror, AI consumers see `[label](pathname:///foo.md)` literally.
+// Strip it here so the public Markdown has clean URLs.
+function stripDocusaurusProtocols( body ) {
+	return body.replace( /pathname:\/\//g, '' );
+}
+
 function transformFrontmatter( content ) {
 	const m = content.match( /^---\n([\s\S]*?)\n---\n?/ );
-	if ( ! m ) return { fm: {}, body: content, transformed: content };
+	if ( ! m ) {
+		const cleaned = stripDocusaurusProtocols( content );
+		return { fm: {}, body: cleaned, transformed: cleaned };
+	}
 
 	let fm;
 	try { fm = yaml.load( m[ 1 ] ) || {}; }
-	catch { return { fm: {}, body: content, transformed: content }; }
+	catch {
+		const cleaned = stripDocusaurusProtocols( content );
+		return { fm: {}, body: cleaned, transformed: cleaned };
+	}
 
 	const cleaned = Object.fromEntries(
 		Object.entries( fm ).filter( ( [ k ] ) => ! DOCUSAURUS_KEYS.has( k ) )
 	);
-	const body = content.slice( m[ 0 ].length ).replace( /^\n+/, '' );
+	const body = stripDocusaurusProtocols(
+		content.slice( m[ 0 ].length ).replace( /^\n+/, '' )
+	);
 
 	let transformed;
 	if ( Object.keys( cleaned ).length === 0 ) {
@@ -155,7 +173,7 @@ walk( SRC );
 		const noFrontmatter = raw.replace( /^---\n[\s\S]*?\n---\n?/, '' );
 		const m = noFrontmatter.match( /^## The prompt[\s\S]*?\n---\n+([\s\S]*)$/m );
 		if ( m ) {
-			const body = m[ 1 ].trim() + '\n';
+			const body = stripDocusaurusProtocols( m[ 1 ].trim() ) + '\n';
 			const out = path.join( DEST, 'Client', 'ai-integration-prompt.md' );
 			fs.mkdirSync( path.dirname( out ), { recursive: true } );
 			fs.writeFileSync( out, body );


### PR DESCRIPTION
Follow-up to #4. Adds a standalone Markdown file at `/Client/ai-integration-prompt.md` containing only the prompt body — no frontmatter, no human-facing intro, no "How to use it" section. Useful for AI tools and chat assistants that accept a prompt URL as input.

The file is extracted from `docs/Client/integration-prompt.md` (single source of truth) by `scripts/mirror-md.js` on every `prestart` / `prebuild`. There is no rendered HTML page and no sidebar entry — only the `.md` URL is reachable, so it stays out of the human navigation.

## Test plan

- [x] `npm run build` produces `build/Client/ai-integration-prompt.md` with the prompt body only
- [x] File starts directly with "You are a senior WordPress plugin engineer..." (no frontmatter)
- [x] No corresponding HTML page (visit `/Client/ai-integration-prompt` without `.md` → 404)
- [x] Cross-linked from `/Client/integration-prompt` and `/for-ai-tools`