### PR TITLE
fix(docs): broken numeric-prefix links in Client + Connector

### DIFF
--- a/docs/Client/01-intro.md
+++ b/docs/Client/01-intro.md
@@ -24,5 +24,5 @@ Customer support is a critical part of any business. TrustedLogin makes it easy 
 
 Two paths, same destination:
 
-- **Step-by-step:** Start with the [Installation guide](./02-installation) and walk through each piece (Composer, namespacing, configuration, bootstrap). Best when you want to learn the system as you go.
-- **AI-assisted (or comprehensive checklist):** Paste the [AI Integration Prompt](./integration-prompt) into your AI coding assistant (Claude Code, Cursor, GitHub Copilot Chat, etc.) — it bundles every step into a single self-contained recipe with input collection, host-side conflict detection, and a verification checklist. Distilled from end-to-end testing across real plugins. Also works as the most thorough walkthrough for humans who want the deepest version of the docs.
+- **Step-by-step:** Start with the [Installation guide](./02-installation.md) and walk through each piece (Composer, namespacing, configuration, bootstrap). Best when you want to learn the system as you go.
+- **AI-assisted (or comprehensive checklist):** Paste the [AI Integration Prompt](./integration-prompt.md) into your AI coding assistant (Claude Code, Cursor, GitHub Copilot Chat, etc.) — it bundles every step into a single self-contained recipe with input collection, host-side conflict detection, and a verification checklist. Distilled from end-to-end testing across real plugins. Also works as the most thorough walkthrough for humans who want the deepest version of the docs.

--- a/docs/Client/integration-prompt.md
+++ b/docs/Client/integration-prompt.md
@@ -14,7 +14,7 @@ A self-contained, end-to-end walkthrough for integrating the TrustedLogin Client
 
 **Or fetch only the prompt itself**, with no preamble or meta sections, at [`/Client/ai-integration-prompt.md`](pathname:///Client/ai-integration-prompt.md) — that's the pure body starting with "You are a senior WordPress plugin engineer". Useful for tools that take a prompt URL as input and don't need the human-facing wrapper.
 
-**Without an AI assistant:** Read it top-to-bottom as a more thorough version of [Installation](./02-installation) + [Namespacing with Strauss](./namespacing/strauss) + [Configuration](./configuration) + [Merging into an existing composer.json](./namespacing/merging-into-existing-composer). The prompt was distilled from end-to-end testing across real plugins and captures gotchas the per-step docs don't dwell on.
+**Without an AI assistant:** Read it top-to-bottom as a more thorough version of [Installation](./02-installation.md) + [Namespacing with Strauss](./namespacing/strauss.md) + [Configuration](./configuration.md) + [Merging into an existing composer.json](./namespacing/merging-into-existing-composer.md). The prompt was distilled from end-to-end testing across real plugins and captures gotchas the per-step docs don't dwell on.
 
 The recipe is verified end-to-end by the [integration tests](https://github.com/trustedlogin/docs/tree/main/tests) in this docs repo — if you follow this prompt and the result differs from what the tests assert, the tests are ground truth.
 

--- a/docs/Connector/help-scout.md
+++ b/docs/Connector/help-scout.md
@@ -26,7 +26,7 @@ Now, switch to your website where you're running the TrustedLogin Connector plug
 
 ## Grab the configuration values from the TrustedLogin plugin {#grab-the-configuration-values-from-the-trustedlogin-plugin}
 
-If you haven't added any teams to the TrustedLogin Connector plugin yet, [do that first!](../01-intro)
+If you haven't added any teams to the TrustedLogin Connector plugin yet, [do that first!](./01-intro.md)
 
 Then, on the TrustedLogin Teams page, click on the Configure Help Desk link.
 


### PR DESCRIPTION
Reported via the broken `docs.trustedlogin.com/Client/02-installation` link from the Client SDK intro page.

## Root cause

Three intra-doc links pointed at the literal numeric-prefixed filename (e.g. `./02-installation`) but Docusaurus auto-strips the `0X-` prefix from the URL slug at build time. Published URLs are `/Client/installation`, `/Client/intro`, etc. — the literal-prefix references 404 in production.

## Fix

Appended `.md` to each link target. Docusaurus resolves `.md` links through its file → slug graph regardless of prefix-stripping, so the links survive future renames and slug-config changes.

| File | Old | New |
|---|---|---|
| `docs/Client/01-intro.md:27` | `./02-installation` | `./02-installation.md` |
| `docs/Client/01-intro.md:28` | `./integration-prompt` | `./integration-prompt.md` (consistency) |
| `docs/Client/integration-prompt.md:17` | four sibling refs without `.md` | all four gained `.md` |
| `docs/Connector/help-scout.md:29` | `../01-intro` | `./01-intro.md` |

The Connector help-scout one was doubly wrong: `../` went up to `docs/` where no `01-intro` lives, AND was missing the extension. Fixed to `./01-intro.md` (same dir) so it resolves to the Connector intro the surrounding copy actually refers to.

## Test plan

- [ ] CI / Docusaurus build runs broken-link checker green
- [ ] After deploy: visit `/Client/intro`, click "Installation guide" → lands on `/Client/installation`
- [ ] Visit `/Connector/help-scout`, click "do that first!" → lands on `/Connector/intro`
